### PR TITLE
fix camera reset after shot, ball placement fix.

### DIFF
--- a/Courses/Range/range.gd
+++ b/Courses/Range/range.gd
@@ -88,13 +88,8 @@ func reset_camera_to_start() -> void:
 
 	await tween.finished
 
-	# Reset ball to starting position so it's visible for next shot
-	$Player.ball.position = Vector3(0.0, 0.2, 0.0)
-	$Player.ball.velocity = Vector3.ZERO
-	$Player.ball.omega = Vector3.ZERO
-	$Player.ball.state = GolfBall.BallState.REST
-
-	# Keep follow mode disabled - it will re-enable when the next shot starts
+	# Reset ball to starting position
+	$Player.ball.reset()
 
 
 func _on_range_ui_hit_shot(data: Dictionary) -> void:
@@ -102,6 +97,12 @@ func _on_range_ui_hit_shot(data: Dictionary) -> void:
 	raw_ball_data = data.duplicate()
 	_update_ball_display()
 
+	# Re-enable camera follow if the setting is on
+	if GlobalSettings.range_settings.camera_follow_mode.value:
+		set_camera_follow_mode(true)
+
+
+func _on_player_manual_hit() -> void:
 	# Re-enable camera follow if the setting is on
 	if GlobalSettings.range_settings.camera_follow_mode.value:
 		set_camera_follow_mode(true)

--- a/Courses/Range/range.tscn
+++ b/Courses/Range/range.tscn
@@ -313,6 +313,7 @@ script = ExtResource("21_6rpr1")
 [connection signal="hit_ball" from="TCPServer" to="Player" method="_on_tcp_client_hit_ball"]
 [connection signal="bad_data" from="Player" to="TCPServer" method="_on_player_bad_data"]
 [connection signal="good_data" from="Player" to="TCPServer" method="_on_golf_ball_good_data"]
+[connection signal="manual_hit" from="Player" to="." method="_on_player_manual_hit"]
 [connection signal="rest" from="Player" to="." method="_on_golf_ball_rest"]
 [connection signal="rest" from="Player" to="SessionRecorder" method="_on_golf_ball_rest"]
 [connection signal="hit_shot" from="RangeUI" to="." method="_on_range_ui_hit_shot"]

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -19,6 +19,7 @@ var ball : GolfBall = null
 signal good_data
 signal bad_data
 signal rest(data: Dictionary)
+signal manual_hit
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -26,6 +27,7 @@ func _ready() -> void:
 	ball = GolfBall.new(GolfBall.BallType.STANDARD)
 	ball.position.y = 3.0
 	add_child(ball)
+	ball.rest.connect(_on_ball_rest)
 	
 	# Set initial value and connect to setting changes
 	max_tracers = GlobalSettings.range_settings.shot_tracer_count.value
@@ -80,6 +82,7 @@ func _process(_delta: float) -> void:
 			current_tracer.add_point(Vector3(0.0, 0.05, 0.0))
 		track_points = true
 		trail_timer = 0.0
+		emit_signal("manual_hit")
 	if Input.is_action_just_pressed("reset"):
 		ball.call_deferred("reset")
 		apex = 0.0


### PR DESCRIPTION
- Fixes camera reset after a shot. Previously was stuck on ball after hit. 
- When camera reset, ball was above ground too high. Now fixed.